### PR TITLE
fix xmlEncode and concat sed command

### DIFF
--- a/workflowHandler.sh
+++ b/workflowHandler.sh
@@ -42,7 +42,7 @@ getXMLResults() {
 # Escapes XML special characters with their entities
 ###############################################################################
 xmlEncode() {
-  echo "$1" | sed s/"&"/"\&amp;"/ | sed s/">"/"\&gt;"/ | sed s/"<"/"\&lt;"/ | sed s/"\'"/"\&apos;"/ | sed s/"\""/"\&quot;"/
+  echo "$1" | sed -e 's/&/\&amp;/g' -e 's/>/\&gt;/g' -e 's/</\&lt;/g' -e "s/'/\&apos;/g" -e 's/"/\&quot;/g'
 }
 
 ###############################################################################


### PR DESCRIPTION
1. fix '
   Otherwise, you get

``` xml
<?xml version="1.0"?>
<items>
  <item uid="uid'" arg="arg'" valid="valid" autocomplete="autocomplete">
    <title>title'</title>
    <subtitle>subtitle'</subtitle>
    <icon>icon.png'</icon>
  </item>
</items>
```

extra ' is added to each item
1. should add /g for sed 
2. faster to concatenate sed commands
