### PR TITLE
Add ability to manage fileicon and filetype for icon param

### DIFF
--- a/workflowHandler.sh
+++ b/workflowHandler.sh
@@ -17,7 +17,18 @@ RESULTS=()
 # $7 autocomplete
 ###############################################################################
 addResult() {
-  RESULT="<item uid='$(xmlEncode "$1")' arg='$(xmlEncode "$2")' valid='$6' autocomplete='$7'><title>$(xmlEncode "$3")</title><subtitle>$(xmlEncode "$4")</subtitle><icon>$(xmlEncode "$5")</icon></item>"
+  RESULT="<item uid=\"$(xmlEncode "$1")\" arg=\"$(xmlEncode "$2")\" valid=\"$6\" autocomplete=\"$7\"><title>$(xmlEncode "$3")</title><subtitle>$(xmlEncode "$4")</subtitle>"
+  if [[ $5 =~ fileicon:* ]]; then
+    icon=`echo $5 | sed -e 's/fileicon://g'`
+    RESULT="${RESULT}<icon type=\"fileicon\">$(xmlEncode "${icon}")</icon>"
+  elif [[ $5 =~ filetype:* ]]; then
+    icon=`echo $5 | sed -e 's/filetype://g'`
+    RESULT="${RESULT}<icon type=\"filetype\">$(xmlEncode "${icon}")</icon>"
+  else
+    RESULT="${RESULT}<icon>$(xmlEncode "$5")</icon>"
+  fi
+    RESULT="${RESULT}</item>"
+
   RESULTS+=("$RESULT")
 }
 


### PR DESCRIPTION
Hi,

In "addResult" function, for "icon" parameter, I have needed to use a fileicon instead of a file. So I alter this function for my workflow, but I think this feature can be useful for other people.

Let me know if you think it's a interesting feature.

Regards,
