### PR TITLE
<arg></arg> instead of <item arg="">

### DIFF
--- a/workflowHandler.sh
+++ b/workflowHandler.sh
@@ -17,7 +17,7 @@ RESULTS=()
 # $7 autocomplete
 ###############################################################################
 addResult() {
-  RESULT="<item uid='$(xmlEncode "$1")' arg='$(xmlEncode "$2")' valid='$6' autocomplete='$7'><title>$(xmlEncode "$3")</title><subtitle>$(xmlEncode "$4")</subtitle><icon>$(xmlEncode "$5")</icon></item>"
+  RESULT="<item uid='$(xmlEncode "$1")' valid='$6' autocomplete='$7'><arg>$(xmlEncode "$2")</arg><title>$(xmlEncode "$3")</title><subtitle>$(xmlEncode "$4")</subtitle><icon>$(xmlEncode "$5")</icon></item>"
   RESULTS+=("$RESULT")
 }
 


### PR DESCRIPTION
As of Alfred 2.0.4, <arg></arg> can be used to specify the argument, rather than <item arg="..." ...></item>. This allows for newlines as well as other XML advantages.

I was able to use this modification to pass arguments with newlines to a Copy to Clipboard action in a workflow I've been working on. For that, I had to implement my own escape characters in getXMLResults which I did not include in this PR (https://github.com/cheniel/alfred-comments/blob/master/scripts/lib/workflowHandler.sh). Regardless, this PR modifies the workflow handler to allow for more flexible arguments.

<a href="http://www.alfredforum.com/topic/2282-alfred-203-passing-multiline-text-out-from-a-script-filter-not-supported-fixed-v204-pre-release/">Here is the original issue</a> that led to the Alfred update.

Here is the item in the change log for Alfred 2.0.4:
"Add in <arg></arg> as an optional replacement to <item arg=""> which allows for newlines in the argument and other various xml advantages"
